### PR TITLE
Update to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,37 @@
-# 0.3.0
-  - Added support for logstash 5.0.0
+# Changelog
 
-# 0.2.0
-  - Removed data store feature
-  - Renamed configuration option "key" into "field" to match configuration of translate plugin
-  - Changed main functionality and configuration similar to translate filter (logstash-plugins/logstash-filter-translate)
-  - Added field, destination and override configuration options and their handling from logstash-plugins/logstash-filter-translate/blob/master/lib/logstash/filters/translate.rb
+All notable changes to this project will be documented in this file.
 
-# 0.1.0
-  - forked from meulop/logstash-filter-redis
+## [0.4.0]
+### Added
+- Support for Redis data types: `string`, `hash`, `list`, `set`, and `zset`.
+- `fallback` configuration to set a default value when Redis lookup fails or key is missing.
+- `timeout` option for Redis connection handling.
+- Improved error logging on Redis failures.
+- Enhanced documentation, gemspec metadata, and plugin comments for clarity.
+
+### Changed
+- Connection handling is now lazy and resilient to failures.
+- Internal structure aligned with Logstash plugin best practices for maintainability.
+
+---
+
+## [0.3.0]
+### Added
+- Initial support for Logstash 5.0.0.
+
+---
+
+## [0.2.0]
+### Changed
+- Removed the data store feature.
+- Renamed configuration option `key` to `field` to match the `translate` plugin convention.
+- Aligned plugin behavior with [logstash-filter-translate](https://github.com/logstash-plugins/logstash-filter-translate):
+  - Introduced `field`, `destination`, and `override` settings.
+  - Updated logic to reflect `translate`-style mappings.
+
+---
+
+## [0.1.0]
+### Added
+- Initial fork from [meulop/logstash-filter-redis](https://github.com/meulop/logstash-filter-redis).

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,6 +5,7 @@ Contributors:
 * Aaron Mildenstein (untergeek)
 * Pier-Hugues Pellerin (ph)
 * Markus Paaso (make)
+* David Rosada (Psych0meter)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/README.md
+++ b/README.md
@@ -1,8 +1,41 @@
-# Logstash Plugin
+# Logstash Filter Plugin: Redis Lookup
 
-This is a plugin for [Logstash](https://github.com/elastic/logstash).
+This is a custom [Logstash](https://github.com/elastic/logstash) filter plugin that enriches event data by querying a Redis datastore. The plugin retrieves values from Redis using a field in the event as the lookup key and supports various Redis data types (`string`, `hash`, `list`, `set`, `zset`).
 
-It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
+It is fully free and open source under the Apache 2.0 License.
+
+## 🔧 Features
+
+- Look up values from Redis based on a specified event field.
+- Supports Redis types: `string`, `hash`, `list`, `set`, and `zset`.
+- Optional fallback value if the key is not found or Redis is unreachable.
+- Configurable key source field, destination field, and override behavior.
+
+## 📄 Configuration Example
+
+```logstash
+filter {
+  redis {
+    host => "localhost"
+    port => 6379
+    db => 0
+    field => "user_id"
+    destination => "user_data"
+    override => true
+    fallback => "unknown"
+  }
+}
+````
+
+## 🧠 How It Works
+
+Given an event field (e.g., `user_id`), the plugin queries Redis for a key matching the field’s value. Based on the key type, the plugin updates the event with the corresponding value(s):
+
+* For a `string`, the value is set directly at the destination field.
+* For a `hash`, each field in the hash becomes a nested field under the destination.
+* For a `list`, `set`, or `zset`, the destination field is set to an array of values.
+
+If the Redis key does not exist or an error occurs, the plugin can optionally populate the destination field with a fallback value.
 
 ## Documentation
 

--- a/logstash-filter-redis.gemspec
+++ b/logstash-filter-redis.gemspec
@@ -1,13 +1,14 @@
 Gem::Specification.new do |s|
 
   s.name = 'logstash-filter-redis'
-  s.version = '0.3.0'
-  s.licenses = ['Apache License (2.0)']
-  s.summary = "This filter allows the storage of event fields in a redis key to be retrieved by a later event"
-  s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
-  s.authors = ["meulop","make"]
-  s.email = 'markus.paaso@gmail.com'
-  s.homepage = "https://github.com/make/logstash-redis-filter"
+  s.version = '0.4.0'
+  s.licenses = ['Apache-2.0']
+  s.summary = "Logstash filter plugin for enriching events with values from Redis."
+  s.description = "This plugin allows Logstash to enrich event data by looking up values from Redis using a specified field as a key. It supports Redis types including string, hash, list, set, and zset. Install using: $LS_HOME/bin/logstash-plugin install logstash-filter-redis."
+
+  s.authors = ["meulop", "make", "Psych0meter"]
+  s.email = 'psychometer@chpavaldon.com'
+  s.homepage = "https://github.com/Psych0meter/logstash-filter-redis"
   s.require_paths = ["lib"]
 
   # Files
@@ -16,13 +17,16 @@ Gem::Specification.new do |s|
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
-  # Special flag to let us know this is actually a logstash plugin
+  # Metadata to identify this as a Logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
-  # Gem dependencies
+  # Runtime dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "redis", '>= 3.0.0', '< 4.0.0'
+  s.add_runtime_dependency "redis", ">= 4.0.1", "< 5"
 
-  s.add_development_dependency 'logstash-devutils', "= 1.1.0"
+  # Development dependencies
+  s.add_development_dependency 'logstash-devutils', ">= 2.6", "< 2.7"
+
+  # Ruby version constraint
+  s.required_ruby_version = '>= 3.0'
 end
-


### PR DESCRIPTION
### Added
- Support for Redis data types: `string`, `hash`, `list`, `set`, and `zset`.
- `fallback` configuration to set a default value when Redis lookup fails or key is missing.
- `timeout` option for Redis connection handling.
- Improved error logging on Redis failures.
- Enhanced documentation, gemspec metadata, and plugin comments for clarity.

### Changed
- Connection handling is now lazy and resilient to failures.
- Internal structure aligned with Logstash plugin best practices for maintainability.